### PR TITLE
Remove login flow and use guest session

### DIFF
--- a/database.py
+++ b/database.py
@@ -170,6 +170,27 @@ def get_user_by_email(email: str) -> Optional[sqlite3.Row]:
     return row
 
 
+def get_or_create_guest_user() -> sqlite3.Row:
+    """Return the shared guest user record, creating it on first use."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM users WHERE email = ?", ("guest@example.com",))
+    row = cur.fetchone()
+    if row:
+        conn.close()
+        return row
+
+    cur.execute(
+        "INSERT INTO users (email, name, password_hash, created_at) VALUES (?, ?, ?, ?)",
+        ("guest@example.com", "ゲストユーザー", None, datetime.utcnow().isoformat()),
+    )
+    conn.commit()
+    cur.execute("SELECT * FROM users WHERE id = ?", (cur.lastrowid,))
+    row = cur.fetchone()
+    conn.close()
+    return row
+
+
 def update_user_plan(user_id: int, plan: str) -> None:
     conn = get_connection()
     cur = conn.cursor()


### PR DESCRIPTION
## Summary
- remove the Streamlit login and registration views in favour of always showing the main app
- introduce a shared guest user record and initialise the session with it
- keep plan management functional by refreshing the guest user details after upgrades

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e3adeb2b4c83239a5d7265f01f21fb